### PR TITLE
Add arm64 Docker image support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,11 +31,11 @@ jobs:
       - name: Build
         run: make
 
-      - name: Test
-        run: make container
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+
+      - name: Test
+        run: make container
 
       - name: Login to ghcr
         uses: docker/login-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Test
-        run: make container
+        run: make multi-arch
 
       - name: Login to ghcr
         uses: docker/login-action@v3

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,9 @@ jobs:
       - name: Test
         run: make container
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Login to ghcr
         uses: docker/login-action@v3
         with:
@@ -41,5 +44,10 @@ jobs:
           username: jamesread
           password: ${{ secrets.CONTAINER_TOKEN }}
 
-      - name: Push to ghcr
-        run: docker push ghcr.io/jamesread/uncomplicated-alert-receiver:latest
+      - name: Build and push multi-platform container
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ghcr.io/jamesread/uncomplicated-alert-receiver:latest

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ default:
 container:
 	docker stop uar || true
 	docker rm uar || true
-	docker build -t ghcr.io/jamesread/uncomplicated-alert-receiver .
+	docker buildx create --use --name multi-arch-builder || true
+	docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/jamesread/uncomplicated-alert-receiver --load .
 
 devcontainer: container
 	docker run -d --name uar -p 8080:8080 ghcr.io/jamesread/uncomplicated-alert-receiver

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,11 @@ container:
 	docker stop uar || true
 	docker rm uar || true
 	docker buildx create --use --name multi-arch-builder || true
-	docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/jamesread/uncomplicated-alert-receiver --load .
+	docker buildx build --platform $(shell uname -m | grep -q "arm64\|aarch64" && echo "linux/arm64" || echo "linux/amd64") -t ghcr.io/jamesread/uncomplicated-alert-receiver --load .
+
+multi-arch:
+	docker buildx create --use --name multi-arch-builder || true
+	docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/jamesread/uncomplicated-alert-receiver .
 
 devcontainer: container
 	docker run -d --name uar -p 8080:8080 ghcr.io/jamesread/uncomplicated-alert-receiver

--- a/Makefile
+++ b/Makefile
@@ -4,11 +4,13 @@ default:
 container:
 	docker stop uar || true
 	docker rm uar || true
-	docker buildx create --use --name multi-arch-builder || true
+	docker buildx inspect multi-arch-builder >/dev/null 2>&1 || docker buildx create --name multi-arch-builder
+	docker buildx use multi-arch-builder
 	docker buildx build --platform $(shell uname -m | grep -q "arm64\|aarch64" && echo "linux/arm64" || echo "linux/amd64") -t ghcr.io/jamesread/uncomplicated-alert-receiver --load .
 
 multi-arch:
-	docker buildx create --use --name multi-arch-builder || true
+	docker buildx inspect multi-arch-builder >/dev/null 2>&1 || docker buildx create --name multi-arch-builder
+	docker buildx use multi-arch-builder
 	docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/jamesread/uncomplicated-alert-receiver .
 
 devcontainer: container


### PR DESCRIPTION
## Problem

The current Docker image only supports the amd64 architecture, causing errors when trying to run on ARM64-based systems (like Raspberry Pi or arm-based VPS servers):

```
The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
```

## Changes

- Modified the Makefile to use Docker Buildx for multi-architecture builds
- Updated GitHub workflow to build and push Docker images for both AMD64 and ARM64


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
	- Updated build processes to produce and publish multi-architecture container images (linux/amd64 and linux/arm64), both in GitHub Actions and local builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->